### PR TITLE
Update default key path

### DIFF
--- a/src/encryption/encryption.ts
+++ b/src/encryption/encryption.ts
@@ -36,7 +36,7 @@ export type EncryptionOptions = {
  * Encrypts and packages all files into an asar archive.
  */
 export async function encrypt({
-  keyFilePath = join(__dirname, 'src/key.txt'),
+  keyFilePath = join(__dirname, 'key.txt'),
   key: keyPlaintext,
   src,
   dst,


### PR DESCRIPTION
**Summary of Changes**

1. The default key path was incorrect: `asarmor/build/src/encryption/src/key.txt`
2.  10d5092f60505a6ca57b2b0d2f44ca2222b1f684 removes the extra `src` from the path, which now resolves to `asarmor/build/src/encryption/key.txt`

