### PR TITLE
ignore key.txt in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 example/
 .idea/
 .github/
+key.txt


### PR DESCRIPTION
**Summary of Changes**

1. Ignore local `key.txt` in `.npmignore`

The local `key.txt` files (from the machine that publishes) have been getting pushed to the npm registry 
Since the keygen script will only generate the key if there isn't one already, it has been leaving the one pulled from the registry to use instead