### PR TITLE
Fix: Asar header file offset type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "asarmor",
-  "version": "2.1.0-beta.8",
+  "version": "2.1.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "asarmor",
-      "version": "2.1.0-beta.8",
+      "version": "2.1.0-beta.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3160,14 +3160,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001274",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
-      "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==",
+      "version": "1.0.30001356",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001356.tgz",
+      "integrity": "sha512-/30854bktMLhxtjieIxsrJBfs2gTM1pel6MXKF3K+RdIVJZcsn2A2QdhsuR4/p9+R204fZw0zCBBhktX8xWuyQ==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -9988,9 +9994,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001274",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
-      "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==",
+      "version": "1.0.30001356",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001356.tgz",
+      "integrity": "sha512-/30854bktMLhxtjieIxsrJBfs2gTM1pel6MXKF3K+RdIVJZcsn2A2QdhsuR4/p9+R204fZw0zCBBhktX8xWuyQ==",
       "dev": true
     },
     "chalk": {

--- a/src/asar.ts
+++ b/src/asar.ts
@@ -8,15 +8,6 @@ export interface File {
    * Offset that specifies where the stored file bytes begin in the archive.
    */
   offset: string;
-
-  integrity?: FileIntegrity;
-}
-
-export interface FileIntegrity {
-  algorithm: 'SHA256';
-  hash: string;
-  blockSize: number;
-  blocks: Buffer[];
 }
 
 export interface FileEntries {

--- a/src/asar.ts
+++ b/src/asar.ts
@@ -7,7 +7,16 @@ export interface File {
   /**
    * Offset that specifies where the stored file bytes begin in the archive.
    */
-  offset: number;
+  offset: string;
+
+  integrity?: FileIntegrity;
+}
+
+export interface FileIntegrity {
+  algorithm: 'SHA256';
+  hash: string;
+  blockSize: number;
+  blocks: Buffer[];
 }
 
 export interface FileEntries {

--- a/src/asarmor.test.ts
+++ b/src/asarmor.test.ts
@@ -5,7 +5,7 @@ test('can patch archive', () => {
   const asarmor = new Asarmor('', {
     header: {
       files: {
-        'foo.txt': { offset: 0, size: 0 },
+        'foo.txt': { offset: '0', size: 0 },
       },
     },
     headerSize: 0,
@@ -14,7 +14,7 @@ test('can patch archive', () => {
   const archive = asarmor.patch({
     header: {
       files: {
-        'bar.txt': { offset: 0, size: 0 },
+        'bar.txt': { offset: '0', size: 0 },
       },
     },
   });
@@ -85,7 +85,7 @@ test('can patch filenames in directories', () => {
         bar: {
           files: {
             baz: {
-              offset: 0,
+              offset: '0',
               size: 0,
             },
           },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,10 +2,12 @@ export function random(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function randomItem(items: any[]) {
   return items[random(0, items.length - 1)];
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createNestedObject(base: any, names: string[], value: any) {
   // If a value is given, remove the last name and keep it for later:
   const lastName = arguments.length === 3 ? names.pop() : false;

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -75,7 +75,11 @@ export function createTrashPatch(options?: {
     let subdirs = filename.split(/[/\\]/);
     if (subdirs.length > 1) {
       subdirs = subdirs.join('_files_').split('_'); // subdirs: ['a', 'foo.txt'] -> ['a', 'files', 'foo.txt']
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const parent = subdirs.shift()!; // subdirs: ['a', 'files', 'foo.txt'] -> ['files', 'foo.txt']
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const obj: any = files[parent] || {};
       createNestedObject(obj, subdirs, { size, offset });
       files[parent] = obj;

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -20,7 +20,7 @@ export function createBloatPatch(gigabytes = 10): Patch {
     while (Object.keys(files).indexOf(filename) > -1)
       filename = randomBytes(30).toString('hex');
 
-    files[filename] = { offset: 0, size: 1 * 1024 * 1024 * 1024 };
+    files[filename] = { offset: '0', size: 1 * 1024 * 1024 * 1024 };
   }
 
   return {
@@ -81,13 +81,13 @@ export function createTrashPatch(options?: {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const obj: any = files[parent] || {};
-      createNestedObject(obj, subdirs, { size, offset });
+      createNestedObject(obj, subdirs, { size, offset: offset.toString() });
       files[parent] = obj;
     }
     // regular file
     // e.g. foo.txt
     else {
-      files[fileName] = { size, offset };
+      files[fileName] = { size, offset: offset.toString() };
     }
   }
 


### PR DESCRIPTION
## Background 

The generated headers result in the offset type becoming a `number`. The [Asar spec](https://github.com/electron/asar/) says:
> offset is a UINT64 number represented in string

However, since this value is read using `parseInt`, the generated Asar file is still "valid". While this isn't a significant issue, it allows for specific bypasses.

```json
{
  "files": {
    "secrets": {
      "size": 4.726805773341905e+307,
      "offset": 2439541280
    },
    "src": {
      "files": {
        "index.js": {
          "size": 161,
          "offset": "0",
          "integrity": {
            "algorithm": "SHA256",
            "hash": "4cfe687e3bcddcdc9343c036e3e3fe17736c03e7988be1952518f9541996cff8",
            "blockSize": 4194304,
            "blocks": [
              "4cfe687e3bcddcdc9343c036e3e3fe17736c03e7988be1952518f9541996cff8"
            ]
          }
        }
      }
    }
  }
}
```

## Solution
This PR changes the type to a `string` by updating the corresponding interface and the patch functions, resulting in the following header:

```json
{
  "files": {
    "secrets": {
      "size": 3.8172653060486633e+307,
      "offset": "1736945459"
    },
    "src": {
      "files": {
        "index.js": {
          "size": 161,
          "offset": "0",
          "integrity": {
            "algorithm": "SHA256",
            "hash": "4cfe687e3bcddcdc9343c036e3e3fe17736c03e7988be1952518f9541996cff8",
            "blockSize": 4194304,
            "blocks": [
              "4cfe687e3bcddcdc9343c036e3e3fe17736c03e7988be1952518f9541996cff8"
            ]
          }
        }
      }
    }
  }
}
```

## Additional
This PR also adds minor additional linting fixes to suppress minor warnings.